### PR TITLE
Drop the prefix from fact tables for consistency.

### DIFF
--- a/R/connector.R
+++ b/R/connector.R
@@ -26,7 +26,11 @@ data_connector <- function(date = "latest"){
       attr(fun, "table") <- .x
       fun
     }) %>%
-    set_names(list_tables_s3())
+    set_names(
+      list_tables_s3() %>% 
+        sub('^\\learning_', '', .)
+    )
+   docs_bic <<- .tbl$docs()
   .tbl
 }
 

--- a/R/s3.R
+++ b/R/s3.R
@@ -136,12 +136,11 @@ s3_tbl <- memoise(function(x, date = 'latest'){
 #' @importFrom purrr transpose
 #' @importFrom tidyr nest
 s3_tbl_docs <- function(){
-  docs_bic %>%
-    dplyr::rename(column = column_name, description = column_description) %>% 
+  docs_bic %>%  
     mutate(tbl_fun_name =  table_name) %>%
     select(-table_name) %>%
     group_by(tbl_fun_name, table_description) %>%
-    nest(column_comments = c(column, description))
+    nest(column_comments = c(column_name, column_description))
 }
 
 #' Get help documents
@@ -168,7 +167,7 @@ s3_help <- function(x){
   column_comments <- doc %>%
     pull(column_comments) %>%
     extract2(1) %>%
-    filter(column %in% colnames(tbl_x)) %>% 
+    filter(column_name %in% colnames(tbl_x)) %>% 
     as.list() %>%
     transpose()
 
@@ -186,8 +185,8 @@ s3_help <- function(x){
   for (column in column_comments){
     informant <- informant %>%
       info_columns(
-        columns = column$column,
-        info = column$description
+        columns = column$column_name,
+        info = column$column_description
       )
   }
 

--- a/vignettes/introduction.Rmd
+++ b/vignettes/introduction.Rmd
@@ -72,7 +72,6 @@ knitr::include_graphics("dc-user-group-activity.png", dpi = 144)
 
 ```{r echo = FALSE, warning = FALSE}
 docs_bic <- dcdcr:::docs_bic %>% 
-  dplyr::rename(column = column_name, description = column_description) %>% 
   mutate(table_name = gsub("learning\\_", "", table_name)) %>% 
   tidyr::separate(
     table_name, 
@@ -80,7 +79,7 @@ docs_bic <- dcdcr:::docs_bic %>%
     remove = FALSE
   ) %>% 
   group_by(table_name, content_type, table_type, table_description) %>% 
-  tidyr::nest(columns = c(column, description))
+  tidyr::nest(columns = c(column_name, column_description))
 
 
 


### PR DESCRIPTION
This PR handles the change in name of the fact tables, dropping the `learning_` prefix.